### PR TITLE
basic implementation for field selecting

### DIFF
--- a/pyszuru/__init__.py
+++ b/pyszuru/__init__.py
@@ -45,14 +45,16 @@ class API(_API):
         return t
 
     def search_tag(  # noqa: F811
-        self, search_query: str, page_size: int = 20, show_progress_bar: bool = False
+        self, search_query: str, page_size: int = 20, fields: List[str] = None,
+        show_progress_bar: bool = False
     ) -> Generator[Tag, None, None]:
-        return _search_generic(self, search_query, Tag, page_size, show_progress_bar)
+        return _search_generic(self, search_query, Tag, page_size, fields, show_progress_bar)
 
     def search_post(  # noqa: F811
-        self, search_query: str, page_size: int = 20, show_progress_bar: bool = False
+        self, search_query: str, page_size: int = 20, fields: List[str] = None,
+        show_progress_bar: bool = False
     ) -> Generator[Post, None, None]:
-        return _search_generic(self, search_query, Post, page_size, show_progress_bar)
+        return _search_generic(self, search_query, Post, page_size, fields, show_progress_bar)
 
     def search_by_image(self, image: FileToken) -> List[SearchResult]:  # noqa: F811
         result = self._call(

--- a/pyszuru/search.py
+++ b/pyszuru/search.py
@@ -31,16 +31,20 @@ def _search_generic(
     search_query: str,
     transforming_class: type,
     page_size: int,
+    fields: List[str] = None,
     show_progress_bar: bool = False,
 ) -> Generator[Resource, None, None]:
     offset = 0
     total = None
     with (tqdm() if show_progress_bar else _NullContextManager()) as pbar:
         while True:
+            urlquery = {"offset": offset, "limit": page_size, "query": search_query}
+            if fields != None:
+                urlquery['fields'] = ','.join(fields)
             page = api._call(
                 "GET",
                 transforming_class._get_class_urlparts(),
-                urlquery={"offset": offset, "limit": page_size, "query": search_query},
+                urlquery=urlquery,
             )
             offset = offset + len(page["results"])
             if page["total"] != total:


### PR DESCRIPTION
**Description**
Added rudimentary implementation for [field selecting](https://github.com/rr-/szurubooru/blob/master/doc/API.md#field-selecting) to searches. Support is provided for `API.search_post()`, `API.search_tag()`, and `_search_generic()` methods. This implementation has not been thoroughly tested.

**Example**
A list of strings can be passed to the optional argument `fields`
```python
posts = mybooru.search_post('id:100', fields=['id', 'safety'])
for p in posts:
    print(p._json)

# {'id': 100, 'safety': 'safe'}
```
If not specified, `fields` will not be included in the query string and the server will return a result with all fields.

**Limitations**
- Problems can occur if `'id'` not included in fields for posts, or `'names'` not included in fields for tags. (getters seem to work fine though)
- No client-side validation for fields was included. It seems like it would be relatively straightforward to implement this if need be, but the server's error handling works just as well.